### PR TITLE
rename to atom-toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# Toolbar package
+# `atom-toolbar` package
 
 Displays a configurable toolbar at the top of the workspace.
 
 ## API
 
 This package provides a service that you can use in other Atom packages. To use
-it, include `toolbar` in the `consumedServices` section of your `package.json`:
+it, include `atom-toolbar` in the `consumedServices` section of your `package.json`:
 
 ```json
 {
   "name": "my-package",
   "consumedServices": {
-    "toolbar": {
+    "atom-toolbar": {
       "versions": {
         "^1.0.0": "consumeToolbar"
       }
@@ -35,7 +35,7 @@ module.exports =
     @toolbarTile = null
 ```
 
-The `toolbar` API has four methods:
+The `atom-toolbar` API has four methods:
 
   * `addLeftTile({ item, priority })` - Add a tile to the left side of the
   toolbar. Lower priority tiles are placed further to the left.

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -14,11 +14,11 @@ module.exports =
     @toolbarPanel = atom.workspace.addTopPanel(item: @toolbar)
 
     # Have the command toggle the setting.
-    atom.commands.add 'atom-workspace', 'toolbar:toggle', =>
-      atom.config.set('toolbar.visible', !atom.config.get('toolbar.visible'))
+    atom.commands.add 'atom-workspace', 'atom-toolbar:toggle', =>
+      atom.config.set('atom-toolbar.visible', !atom.config.get('atom-toolbar.visible'))
 
     # Listen to the setting and toggle the view.
-    atom.config.observe 'toolbar.visible', (val) =>
+    atom.config.observe 'atom-toolbar.visible', (val) =>
       if val
         @toolbarPanel.show()
       else

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "toolbar",
+  "name": "atom-toolbar",
   "version": "0.1.0",
   "main": "./lib/main",
   "description": "Displays a configurable toolbar at the top of the workspace.",
-  "repository": "https://github.com/dart-atom/toolbar",
+  "repository": "https://github.com/dart-atom/atom-toolbar",
   "license": "MIT",
   "engines": {
     "atom": "*"
@@ -13,7 +13,7 @@
     "atom-space-pen-views": "^2.0.0"
   },
   "providedServices": {
-    "toolbar": {
+    "atom-toolbar": {
       "description": "A container for UI elements at the top of the workspace",
       "versions": {
         "1.0.0": "provideToolbar"


### PR DESCRIPTION
Rename from `toolbar` to `atom-toolbar`.
